### PR TITLE
add link to mailing list

### DIFF
--- a/layout.html.haml
+++ b/layout.html.haml
@@ -26,6 +26,8 @@
           %li
             %a{href: '/#rubyconf-au'} RubyConf AU
           %li
+            %a{href: 'https://groups.google.com/forum/#!forum/rails-oceania'} Ruby or Rails Mailing List
+          %li
             %a{href: 'https://github.com/rails-oceania/roro/wiki'} Wiki
           %li
             %a{href: 'https://github.com/rails-oceania/roro/wiki/Mentoring'} Mentoring


### PR DESCRIPTION
we need a mailing list link.  unless you just happen to put "oceania" in the query, our list is dead to google.
