### PR TITLE
Remove reference to Rubyconf

### DIFF
--- a/layout.html.haml
+++ b/layout.html.haml
@@ -24,8 +24,6 @@
           %li
             %a{href: '/#railscamp'} Railscamp
           %li
-            %a{href: '/#rubyconf-au'} RubyConf AU
-          %li
             %a{href: 'https://github.com/rails-oceania/roro/wiki'} Wiki
           %li
             %a{href: 'https://github.com/rails-oceania/roro/wiki/Mentoring'} Mentoring

--- a/pages/index.html.haml
+++ b/pages/index.html.haml
@@ -31,13 +31,6 @@
     Please see the official <a href="http://railscamps.com">Rails Camp</a> site
     for more details.
 
-%section#rubyconf-au
-  %h3 RubyConf Australia
-  %p
-    Ruby Australia is the organising body of RubyConf Australia.
-    Please see the official <a href="http://rubyconf.org.au">RubyConf AU</a> site
-    for more details.
-
 %section
   %h3 Join Ruby Australia
   %p


### PR DESCRIPTION
Self explanatory - Conf is over :frowning: 
