### PR TITLE
Removing specific attribution if I can't remember/list them all.

### DIFF
--- a/pages/code-of-conduct.html.md
+++ b/pages/code-of-conduct.html.md
@@ -22,4 +22,4 @@ The Ruby community is a welcoming and friendly place – thank you for being a p
 
 - - -
 
-This Code of Conduct has learned and borrowed much from others - especially [JSConf](http://jsconf.com/codeofconduct.html) and [Jeff Casimir](https://gist.github.com/jcasimir/6992184). Thank you to all who provided inspiration and feedback.
+This Code of Conduct has learned and built upon the efforts from many others, both within the Ruby community and more widely. Thank you to all who provided inspiration and feedback.


### PR DESCRIPTION
This commit is minor in the amount of lines changed, but I do want to document why it should change.

Firstly: read these tweets:
- https://twitter.com/juliepagano/statuses/439468105518297088
- https://twitter.com/juliepagano/statuses/439468219355910144
- https://twitter.com/juliepagano/statuses/439468290218676224

With that in mind:
- Jeff is far from the only source for our Code, but we did lift a lot from his gist for one of our paragraphs.
- I don't believe what Jeff offered is the equivalent to an acceptable Code.
- I certainly do appreciate the hard work of Ashe, Carina, Julie, etc - indeed, it was tweets from them (not to us, but to everyone) which prompted me to get the draft of this Code together.
- Listing only Jeff and not others in the sources is clearly problematic, and it's better to be more general rather than highlighting just the ones I clearly remember.

Given this isn't a change to the Code itself, I'm likely just to merge this anyway within the next day or so, given I do have commit rights. Our Code certainly has room to evolve - I make no claims of it being perfect - and perhaps those future changes could involve removing/rewording the paragraph that's linked to Jeff. I'd love to be a part of those discussions.

(And having written this, I've now seen #30. Sorry @lengarvey, I should have chimed in there. Given I was responsible for pulling the draft together - aided by work from @benschwarz - I feel personally responsible for this, so trying to fix things, one step at a time.)
