### PR TITLE
Update organisers for Sydney Meetup

### DIFF
--- a/pages/meetups/syd.html.haml
+++ b/pages/meetups/syd.html.haml
@@ -17,4 +17,9 @@
 
   %article
     %h4 Organisers
-    %p Steven Ringo (<a href="http://twitter.com/stevenringo">@stevenringo</a>) and Keith Pitty (<a href="http://twitter.com/keithpitty">@keithpitty</a>).
+    %ul
+      %li Andrew Harvey (<a href="http://twitter.com/mootpointer">@mootpointer</a>)
+      %li Kym McInerney (<a href="https://twitter.com/holodigm">@holodigm</a>)
+      %li John D'Agostino (<a href="https://twitter.com/johndagostino">@johndagostino</a>)
+      %li Steven Ringo (<a href="http://twitter.com/stevenringo">@stevenringo</a>)
+      %li Keith Pitty (<a href="http://twitter.com/keithpitty">@keithpitty</a>)

--- a/site/meetups/syd.html
+++ b/site/meetups/syd.html
@@ -84,7 +84,13 @@
         </article>
         <article>
           <h4>Organisers</h4>
-          <p>Steven Ringo (<a href="http://twitter.com/stevenringo">@stevenringo</a>) and Keith Pitty (<a href="http://twitter.com/keithpitty">@keithpitty</a>).</p>
+          <ul>
+            <li>Andrew Harvey (<a href="http://twitter.com/mootpointer">@mootpointer</a>)</li>
+            <li>Kym McInerney (<a href="https://twitter.com/holodigm">@holodigm</a>)</li>
+            <li>John D'Agostino (<a href="https://twitter.com/johndagostino">@johndagostino</a>)</li>
+            <li>Steven Ringo (<a href="http://twitter.com/stevenringo">@stevenringo</a>)</li>
+            <li>Keith Pitty (<a href="http://twitter.com/keithpitty">@keithpitty</a>)</li>
+          </ul>
         </article>
       </section>
     </section>


### PR DESCRIPTION
As per announcement on Tuesday night, Steven Ringo will be standing
down as the primary organiser for the Sydney meetup, replaced with
Andrew, Kym and myself
