### PR TITLE
Replaced Railscamp with Rails Camp sitewide.

### DIFF
--- a/layout.html.haml
+++ b/layout.html.haml
@@ -27,7 +27,7 @@
           %li
             %a{href: '/code-of-conduct.html'} Code of Conduct
           %li
-            %a{href: '/#railscamp'} Railscamp
+            %a{href: '/#railscamp'} Rails Camp
           %li
             %a{href: '/#rubyconf-au'} RubyConf AU
           %li

--- a/pages/articles.html.md
+++ b/pages/articles.html.md
@@ -52,7 +52,7 @@ Rails Girls events have been run in all major cities around Australia multiple t
 
 A [Code of Conduct for Ruby Australia](http://ruby.org.au/code-of-conduct.html) was [developed publicly on GitHub](https://github.com/rubyaustralia/ruby.org.au/pull/21). It was derived from recognised public examples such as [the Python community](http://www.python.org/psf/codeofconduct/) and [JSConf](http://jsconf.com/codeofconduct.html). It was then ratified by the committee members in mid-October, posted live, and shared. All attendees, including sponsors and speakers, at Ruby Australia events are expected and required, to abide by the Code of Conduct when at any Ruby Australia event.
 
-In the recent Railscamp, in November 2013, the organisers had scholarship tickets aimed for women and students. Also at the start of the camp, the topic was addressed and people with high visibility vests were pointed out as point of contact in case any concern may arise.
+In the recent Rails Camp, in November 2013, the organisers had scholarship tickets aimed for women and students. Also at the start of the camp, the topic was addressed and people with high visibility vests were pointed out as point of contact in case any concern may arise.
 
 ## What have we done for the conference?
 
@@ -86,7 +86,7 @@ Furthermore, we can only grow the speaker diversity from our community by improv
 
 ## Summary
 
-We are getting better, particularly when it comes to promoting diversity in the community and contributing to making this a reality. Four years ago (at a 2010 Railscamp) I was the only female at the camp. Two years ago, we had just four female developers. This year, at the conference, we had 52 female attendees. I believe this change over the last year is due to the conscious effort by community members and Ruby Australia to promote Rails Girls events and welcome newcomers into the community. Now, as I said at the beginning, if we can achieve all this in one year, just imagine what more we can do within this coming year. So basically, what we as a community say is that we are trying; we will try harder.
+We are getting better, particularly when it comes to promoting diversity in the community and contributing to making this a reality. Four years ago (at a 2010 Rails Camp) I was the only female at the camp. Two years ago, we had just four female developers. This year, at the conference, we had 52 female attendees. I believe this change over the last year is due to the conscious effort by community members and Ruby Australia to promote Rails Girls events and welcome newcomers into the community. Now, as I said at the beginning, if we can achieve all this in one year, just imagine what more we can do within this coming year. So basically, what we as a community say is that we are trying; we will try harder.
 
 
 ## Reading materials

--- a/pages/committee-members.html.haml
+++ b/pages/committee-members.html.haml
@@ -31,7 +31,7 @@
       %h3 Jason Stirk
       %p.position Treasurer
     .bio
-      %p Jason met Ruby in late 2004, fell in love with its elegance, and met Rails not long after. He lives in Lismore and likes Railscamp T's, game development and underscores.
+      %p Jason met Ruby in late 2004, fell in love with its elegance, and met Rails not long after. He lives in Lismore and likes Rails Camp T's, game development and underscores.
     .contact
       %a{href: 'http://twitter.com/j_stirk'} @j_stirk
       %a{href: 'http://au.linkedin.com/in/jasonstirk/'} LinkedIn

--- a/pages/general_meetings/2012-11-20.html.md
+++ b/pages/general_meetings/2012-11-20.html.md
@@ -24,9 +24,9 @@ PA motions to approve the minutes of last meeting. KPy seconds.
 
 ## Agenda Item #2: President's report (NR)
 
-NR gives thanks to WS for this Railscamp.
+NR gives thanks to WS for this Rails Camp.
 
-NR says we will get a report about next Railscamp at the end of the SGM.
+NR says we will get a report about next Rails Camp at the end of the SGM.
 
 NR gives thanks to MS, KPy and co. for RubyConf, happening in February.
 
@@ -37,9 +37,9 @@ stepping down.
 
 ## Agenda Item #3: Treasurer's report (SvC)
 
-$15,000 left over for seed money for new Railscamps.
+$15,000 left over for seed money for new Rails Camps.
 
-Railscamp 12 is looking cashflow positive, could add to the seed money pile.
+Rails Camp 12 is looking cashflow positive, could add to the seed money pile.
 
 Money is also coming into the accounts from RubyConf ticket purchases and sponsorship money.
 
@@ -90,11 +90,11 @@ Top-tier sponsors for RubyConf are Envato and Real Estate.
 
 Website went up earlier in the month, thanks to Mike Koukoullis and Max Wheeler.
 
-## Agenda Item #6: Railscamp #13 (BS)
+## Agenda Item #6: Rails Camp #13 (BS)
 
-Railscamp 13 will be in Melbourne, organised by Ben Schwarz.
+Rails Camp 13 will be in Melbourne, organised by Ben Schwarz.
 
-Railscamp 6 was the first camp with over 100 people, cost over $200 and had
+Rails Camp 6 was the first camp with over 100 people, cost over $200 and had
 prizes.
 
 Date is last weekend in April next year.

--- a/pages/general_meetings/2013-06-23.html.md
+++ b/pages/general_meetings/2013-06-23.html.md
@@ -74,9 +74,9 @@ Pat Allan asks: "Who's running this next conference?" Answer: "Steve Gilles, Jos
 
 Josh finishes.
 
-### 7. The Next Railscamp
+### 7. The Next Rails Camp
 
-Pat asks if anyone has any idea on where the next Railscamp would be.
+Pat asks if anyone has any idea on where the next Rails Camp would be.
 
 Lachlan Hardy says that "while it's good to go back to the same places, the better idea would be to go to places where we *haven't* been before."
 
@@ -84,7 +84,7 @@ Dylan Lacey says he would be interested in organising one in Brisbane.
 
 Lachie Cox says he would be interested in organising one in Sydney.
 
-Phil Oye asks that some respect be shown to "those of us who are camping" when it comes to deciding where a Railscamp is in Winter. (This Railscamp has been in the MINUSES overnight). Having it in Brisbane during the Winter would be better. Phil also says that there's no harm in queuing up the next *two* Railscamps.
+Phil Oye asks that some respect be shown to "those of us who are camping" when it comes to deciding where a Rails Camp is in Winter. (This Rails Camp has been in the MINUSES overnight). Having it in Brisbane during the Winter would be better. Phil also says that there's no harm in queuing up the next *two* Rails Camps.
 
 OH: Phil suggests: "Mandatory camping."
 
@@ -112,7 +112,7 @@ Josh Price is now Vice President of Ruby Australia.
 
 --
 
-Phil Oye nominates Lachie Cox for GM. Elle Meredith seconds, as does Jason Crane. "\[jokingly\] For the impending Railscamp in Sydney that will happen in Summer". Lachie accepts.
+Phil Oye nominates Lachie Cox for GM. Elle Meredith seconds, as does Jason Crane. "\[jokingly\] For the impending Rails Camp in Sydney that will happen in Summer". Lachie accepts.
 
 Keith Pitty nominates Elle Meredith. Jason Crane seconds. KP: "Ideal because she's representing the diversity in the community." Elle acccepts.
 
@@ -124,19 +124,19 @@ Suggestion to raise Committee Members from 6 to 8 (made by Pat Allan), so that a
 
 Motion passed to expand general committee member numbers to 4.
 
-Josh Price brings up idea of having special spots on the committee for "Railscamp organisers". Motion tabled.
+Josh Price brings up idea of having special spots on the committee for "Rails Camp organisers". Motion tabled.
 
 Motion passed to elect John Barton, Elle Meredith, Lachie Cox and Dylan Lacey to the committee. Ruby Australia site to be updated with these members soon.
 
 ### 8. Discussion of Ruby Australia money
 
-Phil Oye asks if we have a plan with the profit from Railscamps and Ruby Confs. Ben Schwarz says that the money will be used to 'support Ruby and Ruby events', mentions that the charter says that we're a not-for-profit organisation.
+Phil Oye asks if we have a plan with the profit from Rails Camps and Ruby Confs. Ben Schwarz says that the money will be used to 'support Ruby and Ruby events', mentions that the charter says that we're a not-for-profit organisation.
 
 Josh Price says that we need a safe buffer ("of about $50k") just in case of the problem where we might have to cancel a conference.
 
 Phil says "lowering the price of the conference *could* be a good way to use the available money." Josh Price replies: "subsidising ticket prices for students would be a good way too"
 
-John Barton asks "can we formalize that a specific buffer is set aside in the case of emergencies? A specific amount that we know is earmarked so that we can dip into it if need be. \[For Railscamps, etc\]" Motion postponed until next committee meeting. It should be decided then if a report should be presented at the next General Meeting.
+John Barton asks "can we formalize that a specific buffer is set aside in the case of emergencies? A specific amount that we know is earmarked so that we can dip into it if need be. \[For Rails Camps, etc\]" Motion postponed until next committee meeting. It should be decided then if a report should be presented at the next General Meeting.
 
 Ben Schwarz suggests giving groups (such as RailsGirls) a certain chunk of cash to organise events too. Elle Meredith says that she will note down the expenses of the event and notify Ben of them.
 

--- a/pages/general_meetings/2013-11-03.html.md
+++ b/pages/general_meetings/2013-11-03.html.md
@@ -10,7 +10,7 @@
 ### 1. Opening statements
 
 Pat Allan intro to Ruby Australia and what we do.
-All Railscamps and RubyConfs come under the banner
+All Rails Camps and RubyConfs come under the banner
 The local Ruby meets do not come under the banner.
 
 Pat's just the narrator, no official power.
@@ -43,17 +43,17 @@ Pat Allan put forward a motion to approve the financial reports, seconded by Jas
 
 Pat Allan put forward a motion to accept the previous meeting's minutes, seconded by Jason Crane. _Motion carried._
 
-By attending a Railscamp you are automatically a member of Ruby Australia.
+By attending a Rails Camp you are automatically a member of Ruby Australia.
 
 ### 5. Rubyconf
 
 Josh Price talked about RubyConf 2014. On in Feb. Early bird tickets are on sale now. We've sold 100 or so tickets. Call for Proposals is now open till after RailsCamp. Still taking Proposals till it's done. It'll be held in Luna Park in Sydney. Aiming for 400 people or so. If anyone wants to sponsorship available, please talk to Josh Price or Steve Gilles. Keith asked about keynotes, nothing to announce yet. $545 + GST for early birds. 10 tickets or more get a discount. We have a scholarship available, Thoughtworks are sponsoring 8 tickets. Steve Gilles extended a huge thanks to Keith and Martin and the previous RubyConf team. 100 tickets sold without much effort.
 
-### 6. Current Railscamp
+### 6. Current Rails Camp
 
 Lachie is very pleased with this camp and its progress. We try to aim to break even on the camps, so we had to receive sponsorship and increase the ticket price this time. Hopefully it's not something we have to do each year. The scholarship has worked really well. 12 sponsorships were arranged but quite a few people dropped out. Need to tweak that for next camp.
 
-### 7. Next Railscamp
+### 7. Next Rails Camp
 
 Dylan Lacey announces the next camp in QLD, somewhere 2 hours out of Brisbane. Date, location and costs will be announced at Ruby Conf. Sometime before the end of May due to restrictions. Somewhere more beachy. Looking for suggestions. We'll be having an intro session for noobs in each city to see what they might expect.
 
@@ -116,17 +116,17 @@ _Elected unopposed._
 
 ### 10. General Business
 
-#### Railscamp hardware
-Discussion around the hardware for Railscamps. Chris had to do it all, on his own laptop. Would it make sense to purchase some inside the association that would make railscamps easier to organise, someone has to start again.
+#### Rails Camp hardware
+Discussion around the hardware for Rails Camps. Chris had to do it all, on his own laptop. Would it make sense to purchase some inside the association that would make railscamps easier to organise, someone has to start again.
 
 Jason Stirk put forward a motion that some hardware is acquired to be used at events. Seconded by Keith Pitty.
 
-Should we focus on the specific problem just for Railscamps?  Tim McEwan asked about how we move it around the country.
+Should we focus on the specific problem just for Rails Camps?  Tim McEwan asked about how we move it around the country.
 
-Lachie Cox put forward a motion The Ruby Australia committee will take input in aquire hardware to support Railscamps before next Railscamp. Seconded by Leonard Garvey
+Lachie Cox put forward a motion The Ruby Australia committee will take input in aquire hardware to support Rails Camps before next Rails Camp. Seconded by Leonard Garvey
 _Motion passed._
 
-#### Railscamp Internet
+#### Rails Camp Internet
 
 Nigel asked about potential of getting internet to a railscamp.
 
@@ -134,9 +134,9 @@ Brenton says it's really hard.
 
 _Not carried, more discussion required._
 
-####  Railscamp communication
+####  Rails Camp communication
 
-Discussion about how to communicate that some people need help and some can help as Railscamps. Maybe use internal github. twetter? Talk about it with camp organisers. Not really a Ruby Australia issue.
+Discussion about how to communicate that some people need help and some can help as Rails Camps. Maybe use internal github. twetter? Talk about it with camp organisers. Not really a Ruby Australia issue.
 
 ### 11. Any other business
 

--- a/pages/general_meetings/2014-05-10.html.md
+++ b/pages/general_meetings/2014-05-10.html.md
@@ -57,13 +57,13 @@ Greetings from not so sunny Sydney!
 
 It's been another successful year for Ruby Australia supporting the Ruby community in Australia. It's a wonderful community and I'm extremely proud to be a part of it.
 
-Together we've shipped some amazing events: another fantastic Rubyconf, 2 amazing Railscamps, a host of wonderful RailsGirls events, and all of the various meetups that happen around Australia.
+Together we've shipped some amazing events: another fantastic Rubyconf, 2 amazing Rails Camps, a host of wonderful RailsGirls events, and all of the various meetups that happen around Australia.
 
 Most importantly I'd like to thank everyone who's helped to make these events possible as well as all of the committee members past and present. Untold hours of behind the scenes work goes into making these events possible. So if you see an organiser, don't forget to say thanks… :)
 
 It certainly feels to me like our community has grown more diverse, and more vibrant and this should be celebrated.
 
-Thanks everyone, have a great Railscamp!
+Thanks everyone, have a great Rails Camp!
 
 Cheers,
 Josh

--- a/pages/previous-committee-members.html.haml
+++ b/pages/previous-committee-members.html.haml
@@ -117,7 +117,7 @@
       %h3 Keith Pitty
       %p.position President: Jan 2012 &ndash; Jun 2012
     .bio
-      %p A long-time participant, former convener of and occasional presenter at Sydney Ruby meetups, Keith led the organisation of Railscamp 9 at Lake Ainsworth in 2011 and co-organised the inaugural <a href="http://rubyconf.org.au">RubyConfAU</a> in Melbourne in 2013. He runs <a href="http://www.cockatoosoftware.com.au">Cockatoo Software</a>.
+      %p A long-time participant, former convener of and occasional presenter at Sydney Ruby meetups, Keith led the organisation of Rails Camp 9 at Lake Ainsworth in 2011 and co-organised the inaugural <a href="http://rubyconf.org.au">RubyConfAU</a> in Melbourne in 2013. He runs <a href="http://www.cockatoosoftware.com.au">Cockatoo Software</a>.
       %p Away from computers, he loves sport, especially cricket, golf and Aussie Rules. And single malt whisky.
     .contact
       %a{href: 'http://twitter.com/keithpitty'} @keithpitty
@@ -153,7 +153,7 @@
       %h3 Sebastian von Conrad
       %p.position Treasurer: Jan 2012 &ndash; Dec 2012
     .bio
-      %p After growing up in Sweden, Sebastian escaped to the US in 2007 and moved down under in 2009. He now lives in Melbourne with his partner and two fur children, and works as a development manager at <a href="http://www.envato.com">Envato</a>. He is also a certified baseball nut. Having organised Railscamp X, he is excited to continue working with the Australian Ruby community.
+      %p After growing up in Sweden, Sebastian escaped to the US in 2007 and moved down under in 2009. He now lives in Melbourne with his partner and two fur children, and works as a development manager at <a href="http://www.envato.com">Envato</a>. He is also a certified baseball nut. Having organised Rails Camp X, he is excited to continue working with the Australian Ruby community.
     .contact
       %a{href: 'http://twitter.com/vonconrad'} @vonconrad
       %a{href: 'http://au.linkedin.com/in/vonconrad'} LinkedIn

--- a/site/articles.html
+++ b/site/articles.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>
@@ -69,120 +69,120 @@
       </nav>
     </aside>
     <section role='main'>
-      
+
       <h1 id="on_gender_equality_in_the_australian_ruby_community">On Gender Equality in the Australian Ruby Community</h1>
-      
+
       <p>Written by <a href="https://twitter.com/aemeredith">Elle Meredith</a>, one of the RubyConfAU 2014 organisers and a Ruby Australia committee member. It was reviewed by the other conference organisers and committee members before publication.</p>
-      
+
       <p>February 26, 2014</p>
-      
+
       <p>The <a href="http://rubyconf.org.au/">RubyConfAU 2014</a> organisers have come under fire for the conference’s low percentage of female speakers. This started when Ms. Eleanor Saitta, the closing keynote speaker, displayed a final slide, listing 26 women who could have given talks at the conference. If you are short on time, what I would like you to take from this article is that diversity in the Australian Ruby Community is improving but we still have more to do.</p>
-      
+
       <p>Side note, diversity is about marginalised groups and the issues and barriers they face. For the sake of this article, I will concentrate on diversity of gender within the Australian Ruby community.</p>
-      
+
       <h2 id="how_were_the_talks_selected">How were the talks selected?</h2>
-      
+
       <p>We had an open Call for Talks process and there is already a <a href="http://rubyconf.org.au/news#talking-heads">post about how the talk proposals were selected</a>. We had 103 talk proposals; with a mere eight submitted by women, only one of these talks made it through via the blind selection method. I then promoted Kinsey Ann Durham’s talk (with the support from the other organisers) since I believed it would resonate well with newcomers to the community, regardless of gender.</p>
-      
+
       <p>Our objective for talks at the conference was great content for varying audiences and technical levels. I considered the other talks submitted by women and unfortunately I did not feel their content met our objectives. For example, we tried to avoid any talk that concentrated on a specific product, again regardless of speaker gender.</p>
-      
+
       <p>The two talks by Amanda Wagener and Kinsey Ann Durham were called “soft topics” but when reviewing the Twitter stream during the conference, it is obvious that they were two of the most popular talks.</p>
-      
+
       <h2 id="were_we_deliberately_looking_for_women_to_improve_our_gender_diversity">Were we deliberately looking for women to improve our gender diversity?</h2>
-      
+
       <p>Yes, we were. As the conference got closer, I wanted more women to speak and I began looking for tech women outside the Ruby community, who I considered leaders in their field who could inspire the crowd, and provide a role model for the women attendees looking up to them.</p>
-      
+
       <h2 id="about_criticism">About criticism</h2>
-      
+
       <h3 id="how_was_the_criticism_given">How was the criticism given?</h3>
-      
+
       <p>I believe that the criticism was valid. However, providing it within the keynote talk and as the last slide of the last talk might not have been the right medium for it. I also wish the facts were confirmed with the organisers beforehand. For example some of the names listed were invited and declined the invitation.</p>
-      
+
       <p>What is not conducive to positive future progress is pointing the finger and asking the organisers to “defend” themselves because “it is not my job” without an open discussion. In addition, there were many vocal, uninformed voices from all sides conversing online without checking facts.</p>
-      
+
       <h3 id="how_did_the_community_react">How did the community react?</h3>
-      
+
       <p>I love how the Australia Ruby community cares about the topic and I appreciate all the kind words spoken to us as organisers since the conference ended. However, having multiple people tweet at Ms. Saitta, on a medium that is restricted to 140 characters and does not allow for appropriate expression of nuance, might not have been the correct method for an open productive conversation.</p>
-      
+
       <p>The response should come from the organisers, and it should have come sooner. I apologise for the delay, but I wanted to write this after recovering from the conference, in a state of balanced mind to consider everything I wanted to say, in a way that is thoughtful and considerate to many parties.</p>
-      
+
       <h3 id="how_should_it_have_been_done">How should it have been done?</h3>
-      
+
       <p>Again, I believe this should be an open and public discussion. When speaking on stage to a big crowd, it is very rarely a two-way conversation. Ms. Saitta could have approached the organisers to confirm what was and was not done. And lastly, constructive criticism should have come from both sides.</p>
-      
+
       <p>“@rubyconf_au I understand, and I do appreciate that. All I can see are the results, though.” – @Dymaxion, Feb 21</p>
-      
+
       <p>“@cliffordheath You get points for results, not effort. And I’m done here.” – @Dymaxion, Feb 23</p>
-      
+
       <p>If a hacker is to compromise a system, the end result matters a lot, because if the business’ efforts fail, the hacker wins. Unfortunately, or maybe luckily, we are not under attack from hackers. We, as a community, should work to foster a welcoming environment for all, regardless of background or experience. Diversity is about the opportunity to contribute, not the actual outcome.</p>
-      
+
       <h2 id="what_has_been_done_to_improve_diversity_in_the_last_year">What has been done to improve diversity in the last year?</h2>
-      
+
       <p>Rails Girls events have been run in all major cities around Australia multiple times with the support of local volunteers, local businesses and under the umbrella of Ruby Australia (which provides help with insurance, legal matters and finance).</p>
-      
+
       <p>A <a href="http://ruby.org.au/code-of-conduct.html">Code of Conduct for Ruby Australia</a> was <a href="https://github.com/rubyaustralia/ruby.org.au/pull/21">developed publicly on GitHub</a>. It was derived from recognised public examples such as <a href="http://www.python.org/psf/codeofconduct/">the Python community</a> and <a href="http://jsconf.com/codeofconduct.html">JSConf</a>. It was then ratified by the committee members in mid-October, posted live, and shared. All attendees, including sponsors and speakers, at Ruby Australia events are expected and required, to abide by the Code of Conduct when at any Ruby Australia event.</p>
-      
-      <p>In the recent Railscamp, in November 2013, the organisers had scholarship tickets aimed for women and students. Also at the start of the camp, the topic was addressed and people with high visibility vests were pointed out as point of contact in case any concern may arise.</p>
-      
+
+      <p>In the recent Rails Camp, in November 2013, the organisers had scholarship tickets aimed for women and students. Also at the start of the camp, the topic was addressed and people with high visibility vests were pointed out as point of contact in case any concern may arise.</p>
+
       <h2 id="what_have_we_done_for_the_conference">What have we done for the conference?</h2>
-      
+
       <ul>
       <li>We emailed female speakers, from within the industry and related industries and invited them to speak. Out of the women Josh Price or I approached, five said yes, out of which three then cancelled. And the majority of the others turned down our invitation.</li>
-      
+
       <li>We offered to cover travel expenses to speakers.</li>
-      
+
       <li>We offered student discounted tickets. These were also offered to General Assembly alumni.</li>
-      
+
       <li>We offered scholarship tickets.</li>
-      
+
       <li>We asked the speakers to sign an agreement, stating their responsibility to adhere to the Code of Conduct.</li>
-      
+
       <li>We developed and offered the world’s first free Rails Girls Next workshop, and offered the attendees the option to purchase a ticket at student prices, whether they are students or not.</li>
-      
+
       <li>We included beginner level talk options.</li>
-      
+
       <li>We offered shirts in both man and female cuts.</li>
-      
+
       <li>We catered for special dietary requirements and allergies.</li>
-      
+
       <li>We opened up the speakers dinner to be inclusive to anyone who wanted to join. The dinner cost was subsidised by Ruby Australia and did not include alcoholic beverages by default. We also organised Luna Park rides as an non-alcohol centered activity.</li>
       </ul>
-      
+
       <p>On the topic of child care, I had seen it addressed at another conference recently, so I investigated. Unfortunately, the timing was too close to be able to offer it or to be utilised at scale this time around. We did however accommodate a recent new mother, who brought her newborn son to the conference.</p>
-      
+
       <h2 id="things_we_could_have_done_and_should_be_done_next_time">Things we could have done and should be done next time</h2>
-      
+
       <ul>
       <li>Personally invite more diverse speakers. Research the topic and review the list provided in the closing keynote.</li>
-      
+
       <li>Allow the option to submit talks that is not public.</li>
-      
+
       <li>Plan for curated content and be open and transparent about the process of talk selection.</li>
-      
+
       <li>Describe what is provided to accepted speakers.</li>
-      
+
       <li>Consider available resources to help first time speakers.</li>
-      
+
       <li>Introduced the Code of Conduct at the beginning of the conference and explained how to act in case of concerns.</li>
-      
+
       <li>The conference website should have included a name and contact details for the people to contact in the case of something happening.</li>
-      
+
       <li>Child care facilities.</li>
-      
+
       <li>Mentorship program.</li>
       </ul>
-      
+
       <p>Furthermore, we can only grow the speaker diversity from our community by improving the community diversity first (although we can temporarily force an unrepresentative ratio to help drive the change).</p>
-      
+
       <h2 id="summary">Summary</h2>
-      
-      <p>We are getting better, particularly when it comes to promoting diversity in the community and contributing to making this a reality. Four years ago (at a 2010 Railscamp) I was the only female at the camp. Two years ago, we had just four female developers. This year, at the conference, we had 52 female attendees. I believe this change over the last year is due to the conscious effort by community members and Ruby Australia to promote Rails Girls events and welcome newcomers into the community. Now, as I said at the beginning, if we can achieve all this in one year, just imagine what more we can do within this coming year. So basically, what we as a community say is that we are trying; we will try harder.</p>
-      
+
+      <p>We are getting better, particularly when it comes to promoting diversity in the community and contributing to making this a reality. Four years ago (at a 2010 Rails Camp) I was the only female at the camp. Two years ago, we had just four female developers. This year, at the conference, we had 52 female attendees. I believe this change over the last year is due to the conscious effort by community members and Ruby Australia to promote Rails Girls events and welcome newcomers into the community. Now, as I said at the beginning, if we can achieve all this in one year, just imagine what more we can do within this coming year. So basically, what we as a community say is that we are trying; we will try harder.</p>
+
       <h2 id="reading_materials">Reading materials</h2>
-      
+
       <ul>
       <li>Ashe Dryden, <a href="http://www.ashedryden.com/blog/increasing-diversity-at-your-conference">Increasing Diversity at your Conference</a></li>
-      
+
       <li>Julie Pagano, <a href="http://juliepagano.com/blog/2014/01/06/on-making-mistakes">On Making Mistakes</a></li>
       </ul>
     </section>

--- a/site/association.html
+++ b/site/association.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>

--- a/site/code-of-conduct.html
+++ b/site/code-of-conduct.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>
@@ -69,27 +69,27 @@
       </nav>
     </aside>
     <section role='main'>
-      
+
       <h1 id="ruby_australia_code_of_conduct">Ruby Australia Code of Conduct</h1>
-      
+
       <h2 id="matz_is_nice_and_we_are_nice">Matz is nice, and we are nice.</h2>
-      
+
       <p>In the same way that Matz has written Ruby with a focus on developer happiness, we are focused on community happiness. The Australian Ruby community is full of wonderful people from a diverse range of backgrounds, and we want to ensure it remains a welcoming and safe environment to all who wish to be a part of it.</p>
-      
+
       <p>Whenever we come together as a community, our shared spaces are opportunities to showcase the best of what we can be. We are there to support our peers - to build each other up, to accept each other for who they are, and to encourage each other to become the people they want to be.</p>
-      
+
       <p>With that in mind, if you are present at any Ruby Australia event, whether as an attendee, organiser, sponsor or speaker, we take it as given that you agree to follow this code of conduct:</p>
-      
+
       <p>The Ruby Australia organisation is dedicated to providing harassment-free experiences at events and conferences for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, religion, or age. We do not tolerate harassment in any form.</p>
-      
+
       <p>All communication should be appropriate for a professional audience including people of many different backgrounds. Sexual language and imagery is not appropriate in any circumstance.</p>
-      
+
       <p>Be kind to others. Do not insult or put down other members of the community. Be respectful towards others. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for events supported by Ruby Australia.</p>
-      
+
       <p>Anyone violating these rules at events may be asked to leave the event without a refund at the sole discretion of the organisers.</p>
-      
+
       <p>If you or someone else is subject to harassment, or you have a concern, please contact the event organisers (who will introduce themselves at the beginning of the event), or member of <a href="/committee-members.html">the Ruby Australia committee</a>.</p>
-      
+
       <p>The Ruby community is a welcoming and friendly place – thank you for being a part of it.</p>
       <hr />
       <p>This Code of Conduct has learned and built upon the efforts from many others, both within the Ruby community and more widely. Thank you to all who provided inspiration and feedback.</p>

--- a/site/committee-members.html
+++ b/site/committee-members.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>
@@ -109,7 +109,7 @@
             <p class='position'>Treasurer</p>
           </header>
           <div class='bio'>
-            <p>Jason met Ruby in late 2004, fell in love with its elegance, and met Rails not long after. He lives in Lismore and likes Railscamp T's, game development and underscores.</p>
+            <p>Jason met Ruby in late 2004, fell in love with its elegance, and met Rails not long after. He lives in Lismore and likes Rails Camp T's, game development and underscores.</p>
           </div>
           <div class='contact'>
             <a href='http://twitter.com/j_stirk'>@j_stirk</a>

--- a/site/general_meetings/2012-06-16.html
+++ b/site/general_meetings/2012-06-16.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>
@@ -69,265 +69,265 @@
       </nav>
     </aside>
     <section role='main'>
-      
+
       <h1 id="ruby_australia_sgm_minutes">Ruby Australia SGM Minutes</h1>
-      
+
       <p>Held: Rails Camp, Springbrook QLD, June 16, 2012 4PM</p>
-      
+
       <h2 id="committee_members_present">Committee Members Present</h2>
-      
+
       <ul>
       <li>Keith Pitty, President</li>
-      
+
       <li>Nigel Rausch, Vice President</li>
-      
+
       <li>Sebastian von Conrad, Treasurer</li>
-      
+
       <li>Daniel Draper, General Member</li>
       </ul>
-      
+
       <h3 id="apologies">Apologies:</h3>
-      
+
       <ul>
       <li>Ben Schwarz, General Member</li>
-      
+
       <li>Richie Khoo, Secretary</li>
-      
+
       <li>Warren Seen</li>
-      
+
       <li>Martin Stanard</li>
-      
+
       <li>Pat Allan</li>
       </ul>
-      
+
       <h3 id="other_attendees">Other Attendees</h3>
-      
+
       <ul>
       <li>Matt Allen</li>
-      
+
       <li>Jason Crane</li>
-      
+
       <li>Phil Oye</li>
-      
+
       <li>David Goodlad</li>
-      
+
       <li>Jack Chen</li>
-      
+
       <li>Alan Harper</li>
-      
+
       <li>Elle Meredith</li>
-      
+
       <li>Ivan Vanderbyl</li>
-      
+
       <li>Lachie Cox</li>
-      
+
       <li>Steve Gilles</li>
-      
+
       <li>Leonard Garvey</li>
-      
+
       <li>Andrew Grimm</li>
-      
+
       <li>Jon Bartlett</li>
-      
+
       <li>Steven Ringo</li>
-      
+
       <li>Luke Chadwick</li>
-      
+
       <li>Julian Doherty</li>
-      
+
       <li>Ryan Bigg</li>
-      
+
       <li>Michael Harrison</li>
-      
+
       <li>Stuart Coyle</li>
-      
+
       <li>Anton Katunin</li>
-      
+
       <li>Sean Kelly</li>
-      
+
       <li>Craig Read</li>
-      
+
       <li>Trung Le</li>
-      
+
       <li>Adrian Smith</li>
-      
+
       <li>Robert Posthill</li>
-      
+
       <li>Lucas Maxwell</li>
-      
+
       <li>Nathan Sampiamon</li>
-      
+
       <li>Samuel Cochran</li>
-      
+
       <li>Noel Kelly</li>
-      
+
       <li>Robert O’Farrel</li>
-      
+
       <li>David Edwards</li>
-      
+
       <li>Philip Arndt</li>
       </ul>
-      
+
       <h2 id="1_membership">1) Membership</h2>
-      
+
       <p>All attendees to Rails camps are given automatic membership</p>
-      
+
       <h2 id="2_last_meeting_minutes">2) Last meeting minutes</h2>
-      
+
       <p>The President pointed members to the minutes of the last meeting on ideagora.</p>
-      
+
       <h2 id="3_reports">3) Reports</h2>
-      
+
       <h3 id="the_president">The President</h3>
-      
+
       <p>The organisation has now been established. Making progress towards aims.</p>
-      
+
       <ul>
       <li>Smoother transition between camps</li>
-      
+
       <li>Run an australian ruby conference</li>
-      
+
       <li>General promotion</li>
       </ul>
-      
+
       <p>Thanks ben s and david good lad for getting the website up. Thanks to Richie for his establishing work. Thanks to Sebastian in work as treasurer. thanks to Nigel for Rails camp 11. Warren Seen has agreed to organise the next camp in Tasmania. Venue has been booked near sorel for the 16th to the 19th of Nov, 2012.</p>
-      
+
       <p><em>Committee Status</em></p>
-      
+
       <ul>
       <li>Each meeting there will be three members that remain and three that continue for another term. Richie, Ben and Keith will be stepping down this time.</li>
-      
+
       <li>Reps from the next rails camp and the ruby conf should be on the committee.</li>
-      
+
       <li>A public officer must be nominated. This person must be resident in VIC.</li>
       </ul>
-      
+
       <h3 id="the_secretary">The Secretary</h3>
-      
+
       <ul>
       <li>Has set up bank accounts</li>
-      
+
       <li>Formal notices</li>
-      
+
       <li>Welcome guide for new committee members</li>
-      
+
       <li>Suggested guiding principles for the association</li>
       </ul>
-      
+
       <h3 id="the_treasurer">The Treasurer</h3>
-      
+
       <ul>
       <li>Total profit for RC10 $4678.71</li>
-      
+
       <li>Total after last camp: ~$12k</li>
-      
+
       <li>Expected RC11 (thanks to sponsors) should generate a profit of approx $3.5k</li>
-      
+
       <li>Has set Xero for accounting</li>
-      
+
       <li>Some administration performed in regards to bank accounts etc</li>
-      
+
       <li>$2.5k deposit has been made for conference which will be reimbursed to the assn when sponsorship/ticket sales commence</li>
       </ul>
-      
+
       <h2 id="elections">Elections</h2>
-      
+
       <h3 id="president">President</h3>
-      
+
       <ul>
       <li>Daniel Draper, nominated Nigel Rausch</li>
-      
+
       <li>Luke Chadwick, seconded</li>
       </ul>
-      
+
       <p>No other nominations.</p>
-      
+
       <p>Keith declared Nigel as the president.</p>
-      
+
       <h3 id="nominations_for_vp">Nominations for VP</h3>
-      
+
       <ul>
       <li>Keith Pitty, nominated Martin Stanard</li>
-      
+
       <li>Seconded by Matt Allen</li>
       </ul>
-      
+
       <p>No other nominations. Declared.</p>
-      
+
       <h3 id="secretary">Secretary</h3>
-      
+
       <ul>
       <li>Keith nominated Daniel Draper</li>
-      
+
       <li>Seconded by Sebastian von Conrad</li>
       </ul>
-      
+
       <p>No other nominations. Daniel will be the secretary.</p>
-      
+
       <h3 id="treasurer">Treasurer</h3>
-      
+
       <p>Sebastian will continue.</p>
-      
+
       <h3 id="gcm">GCM</h3>
-      
+
       <p>Daniel Draper nominated as Warren Seen. Seconded by Jason Crane</p>
-      
+
       <p>No other nominations</p>
-      
+
       <h3 id="gcm2">GCM2</h3>
-      
+
       <p>David Goodlad nominated himself. Steven Ringo nominated himself.</p>
-      
+
       <p>Steven talked about what he could offer the association. David did also. Mentioned that he built the original site.</p>
-      
+
       <p>Keith asked if members were happy to vote by show of hands.</p>
-      
+
       <p>David voted in by show of hands.</p>
-      
+
       <h2 id="other_business">Other Business</h2>
-      
+
       <p>Keith asked by a member about the Ruby conference. Cory Haines and Aaron Patterson will be keynote speakers.</p>
-      
+
       <p>Thursday and Friday will be the main conference days but considering Wednesday as a tutorial day.</p>
-      
+
       <p>Basic site set up rubyconf.org.au and twitter rubyconf_au</p>
-      
+
       <p>Venue is the Jasper Hotel in Melbourne.</p>
-      
+
       <p>Have established a partnership with Yow. Sabine Wolf will be assisting. This is in a similar way to what Swipeconf did in 2011.</p>
-      
+
       <p>Questions regarding theme. Will the conf be technically focussed? Corporate/Business? How narrow will the conf be - very much about Ruby or more inclusion of JS/CoffeeScript etc.</p>
-      
+
       <p>Talk proposals will probably open up in August 2012.</p>
-      
+
       <p>There will be two conference tracks.</p>
-      
+
       <p>Key organisers at present are:</p>
-      
+
       <ul>
       <li>Keith Pitty</li>
-      
+
       <li>Martin Stanard</li>
-      
+
       <li>Mike Coulis</li>
       </ul>
-      
+
       <p>Next steps:</p>
-      
+
       <ul>
       <li>Locking in sponsors (Martin Stanard has been work on this)</li>
-      
+
       <li>Ticket prices need to be determined</li>
-      
+
       <li>Budget Plannining</li>
-      
+
       <li>Looking for more keynote speakers</li>
       </ul>
-      
+
       <h2 id="closing">Closing</h2>
-      
+
       <p>No other business.</p>
-      
+
       <p>Meeting closed 4:30pm.</p>
     </section>
     <footer role='contentinfo'>

--- a/site/general_meetings/2012-11-20.html
+++ b/site/general_meetings/2012-11-20.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>
@@ -69,125 +69,125 @@
       </nav>
     </aside>
     <section role='main'>
-      
+
       <h1 id="ruby_australia_sgm">Ruby Australia SGM</h1>
-      
+
       <ul>
       <li>NR: Nigel Rausch</li>
-      
+
       <li>PA: Pat Allan</li>
-      
+
       <li>KPy: Keith Pitty</li>
-      
+
       <li>WS: Warren Seen</li>
-      
+
       <li>MS: Martin Stannard</li>
-      
+
       <li>SvC: Sebastian von Conrad</li>
-      
+
       <li>BS: Ben Schwarz</li>
-      
+
       <li>JS: Jason Stirk</li>
-      
+
       <li>RB: Ryan Bigg</li>
       </ul>
-      
+
       <p>Nigel Rausch (president) opens the meeting at 2:10pm.</p>
-      
+
       <p>Minutes by Ryan Bigg</p>
-      
+
       <p>NR: Hands over to Pat Allan.</p>
-      
+
       <p>PA explains Ruby Australia’s purpose to the group.</p>
-      
+
       <h2 id="agenda_item_1_minutes_of_last_meeting_pa">Agenda Item #1: Minutes of last meeting. (PA)</h2>
-      
+
       <p>PA motions to approve the minutes of last meeting. KPy seconds.</p>
-      
+
       <h2 id="agenda_item_2_presidents_report_nr">Agenda Item #2: President’s report (NR)</h2>
-      
-      <p>NR gives thanks to WS for this Railscamp.</p>
-      
-      <p>NR says we will get a report about next Railscamp at the end of the SGM.</p>
-      
+
+      <p>NR gives thanks to WS for this Rails Camp.</p>
+
+      <p>NR says we will get a report about next Rails Camp at the end of the SGM.</p>
+
       <p>NR gives thanks to MS, KPy and co. for RubyConf, happening in February.</p>
-      
+
       <p>NR gives thanks to RK, KPy and PA for their work on establishing Ruby Australia.</p>
-      
+
       <p>NR says 3 committee members are stepping down. NR, SvC and Dan Draper are stepping down.</p>
-      
+
       <h2 id="agenda_item_3_treasurers_report_svc">Agenda Item #3: Treasurer’s report (SvC)</h2>
-      
-      <p>$15,000 left over for seed money for new Railscamps.</p>
-      
-      <p>Railscamp 12 is looking cashflow positive, could add to the seed money pile.</p>
-      
+
+      <p>$15,000 left over for seed money for new Rails Camps.</p>
+
+      <p>Rails Camp 12 is looking cashflow positive, could add to the seed money pile.</p>
+
       <p>Money is also coming into the accounts from RubyConf ticket purchases and sponsorship money.</p>
-      
+
       <p>SvC will compile a more complete financial report towards the end of the year.</p>
-      
+
       <p>SvC says there is now public liability / general license for the Ruby Australia company.</p>
-      
+
       <h2 id="agenda_item_4_nominations_for_committee_members">Agenda Item #4: Nominations for committee members.</h2>
-      
+
       <p><strong>Nominations for President</strong></p>
-      
+
       <ul>
       <li>NR nominates Ben Schwarz. WS seconds.</li>
       </ul>
-      
+
       <p><strong>BS is now the President of Ruby Australia after January.</strong></p>
-      
+
       <p><strong>Martin Stannard continues in role of Vice President.</strong></p>
-      
+
       <p><strong>Nominations for Treasurer</strong></p>
-      
+
       <ul>
       <li>ML nominates Jason Stirk. SvC seconds.</li>
       </ul>
-      
+
       <p><strong>JS is the new Treasurer for Ruby Australia after January.</strong></p>
-      
+
       <p><strong>Nominations for Secretary</strong></p>
-      
+
       <p>Ryan Bigg nominates himself. NR seconds.</p>
-      
+
       <p><strong>RB is the new secretary for Ruby Australia after January.</strong></p>
-      
+
       <p>Warren Seen continues as a general member. David Goodlad continues as a general member.</p>
-      
+
       <h2 id="agenda_item_5_rubyconf_australia_ms">Agenda Item #5: RubyConf Australia (MS)</h2>
-      
+
       <p>RubyConf is from 20th-22nd Feburary 2012. 80% of tickets sold already, estimated two weeks until the tickets run out.</p>
-      
+
       <p>Workshop tickets will be on sale for $100 at the end of this week (around 22nd November)</p>
-      
+
       <p><strong>Workshops</strong></p>
-      
+
       <ul>
       <li>Corey Haines</li>
-      
+
       <li>Rails for iOS</li>
-      
+
       <li>Git talk</li>
-      
+
       <li>RailsGirls workshop</li>
-      
+
       <li>And more!</li>
       </ul>
-      
+
       <p>Top-tier sponsors for RubyConf are Envato and Real Estate.</p>
-      
+
       <p>Website went up earlier in the month, thanks to Mike Koukoullis and Max Wheeler.</p>
-      
-      <h2 id="agenda_item_6_railscamp_13_bs">Agenda Item #6: Railscamp #13 (BS)</h2>
-      
-      <p>Railscamp 13 will be in Melbourne, organised by Ben Schwarz.</p>
-      
-      <p>Railscamp 6 was the first camp with over 100 people, cost over $200 and had prizes.</p>
-      
+
+      <h2 id="agenda_item_6_railscamp_13_bs">Agenda Item #6: Rails Camp #13 (BS)</h2>
+
+      <p>Rails Camp 13 will be in Melbourne, organised by Ben Schwarz.</p>
+
+      <p>Rails Camp 6 was the first camp with over 100 people, cost over $200 and had prizes.</p>
+
       <p>Date is last weekend in April next year.</p>
-      
+
       <p>Meeting closed at 2:31pm by PA.</p>
     </section>
     <footer role='contentinfo'>

--- a/site/general_meetings/2013-06-23.html
+++ b/site/general_meetings/2013-06-23.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>
@@ -69,145 +69,145 @@
       </nav>
     </aside>
     <section role='main'>
-      
+
       <h1 id="ruby_australia_annual_general_meeting_minutes">Ruby Australia Annual General Meeting Minutes</h1>
-      
+
       <p><strong>23rd June, 2013</strong></p>
-      
+
       <p><strong>MEETING OPEN: 5:16 pm</strong></p>
       <hr />
       <h2 id="agenda">Agenda</h2>
-      
+
       <h3 id="1_opening_statements">1. Opening Statements</h3>
-      
+
       <p>Opening statements by PA. Explained what Ruby Australia is.</p>
-      
+
       <p>Martin Stannard (VP) + Jason Stirk (Treasurer) + Warren Seen (General Member) absent.</p>
-      
+
       <p>Steve Gilles is collecting names for those in attendance. <em>OH: “He’s like: ‘What’s your name and are you looking for work? Let me take you to lunch.”</em></p>
-      
+
       <p>Up for grabs: VP spot and 2 General Members spots.</p>
-      
+
       <h3 id="2_treasurers_report">2. Treasurer’s Report</h3>
-      
+
       <p>TODO: Include Jason’s report here (text from Basecamp?)</p>
-      
+
       <p>Clifford Heath asks why there is only $10k in the interest bearing account. The answer is because receipts have not be reconciled and the RubyConf AU 2 venue has not had a deposit put down.</p>
-      
+
       <p>Ben says that the Treasurer’s job is pretty difficult, saying that the handover process needs to be smoother and that is currently being worked on.</p>
-      
+
       <p>Dylan Lacey asks where the receipts information would be available. The answer is on the ruby.org.au site.</p>
-      
+
       <p>Motion approved.</p>
       <hr />
       <p>Lachie Cox asks why the accountants (Interactive Accounting) were selected as opposed to all others. Josh Price and Ben Schwarz explain that on July 1st Ruby Australia will be GST registered finally, due to going over $150k in revenue (thanks to RubyConf AU 1)</p>
-      
+
       <p>Josh Price lets slip that next Ruby Conf AU will be at Luna Park in Sydney.</p>
-      
+
       <p>Ben continues explaining, saying that the accountants were also chosen due to their familarity with Xero, which will make the process of accounting more transparent for the entire organisation.</p>
-      
+
       <p>JP: “They seem pretty sharp. … They don’t do paper, at all.”</p>
-      
+
       <h3 id="3_jason_stirks_reelection">3. Jason Stirk’s Re-election</h3>
-      
+
       <p>Discussion went on that Jason Stirk should be re-elected Treasurer for the next term as well, to make the management of the treasury smoother.</p>
-      
+
       <p>John Barton puts forward the motion for discussion of election terms during the next General Meeting.</p>
-      
+
       <p>Short discussion by Luke Chadwick regarding an “Assistant Treasurer” role. Motion is tabled for now. The role will be observed for 6 months and if the Treasurer needs help then the idea of this role will again be discussed.</p>
-      
+
       <p>Motion Approved for JB’s re-election rules.</p>
-      
+
       <h3 id="4_presidents_report">4. President’s Report</h3>
-      
+
       <p>Ben first thanks Keith Pitty for his initial work on the organisation.</p>
-      
+
       <p>Ben announces Rails Girls support for Ruby Australia:</p>
-      
+
       <p>“The entity exists to change the way Ruby exists in the country; to make it better for the entire community. I think it’s important to support parts of the community, and so Ruby Australia will now be supporting Rails Girls in Australia.”</p>
-      
+
       <p>Motion approved.</p>
-      
+
       <h3 id="5_secretarys_report">5. Secretary’s Report</h3>
-      
+
       <p>Ryan mentions AUSKey paperwork is ongoing. Proper paperwork filed with Consumer Affairs Victoria, and ATO paperwork will be done in the coming week or two. Once this is done, the deposit on RubyConf AU 2 venue will be paid, and the organisation work for RubyConf AU 2 will begin.</p>
-      
+
       <h3 id="6_josh_prices_comments_on_ruby_conf_au_2">6. Josh Price’s comments on Ruby Conf AU 2</h3>
-      
+
       <p>JP announces that Luna Park (in Sydney) is the “primary” venue for Ruby Conf AU. Feb 19th-21st 2014, Wednesday -&gt; Friday. “The main problems with the old venue [in Melbourne], were the lack of space and WiFi problems. We’re doing it properly this time.”</p>
-      
+
       <p>Dylan asks: “When will the call for sponsors open?” Answer by Josh Price: “When we’ve locked in the venue. We want to approach all previous sponsors and give them the option first. Once that’s done, then we’ll open it up to the general. Getting some keynote speakers locked in and getting tickets rolling is what’s after that.”</p>
-      
+
       <p>Pat Allan asks: “Who’s running this next conference?” Answer: “Steve Gilles, Josh Price, Elle Meredith, Jason Crane and Georgina Robilliard”</p>
-      
+
       <p>Josh finishes.</p>
-      
-      <h3 id="7_the_next_railscamp">7. The Next Railscamp</h3>
-      
-      <p>Pat asks if anyone has any idea on where the next Railscamp would be.</p>
-      
+
+      <h3 id="7_the_next_railscamp">7. The Next Rails Camp</h3>
+
+      <p>Pat asks if anyone has any idea on where the next Rails Camp would be.</p>
+
       <p>Lachlan Hardy says that “while it’s good to go back to the same places, the better idea would be to go to places where we <em>haven’t</em> been before.”</p>
-      
+
       <p>Dylan Lacey says he would be interested in organising one in Brisbane.</p>
-      
+
       <p>Lachie Cox says he would be interested in organising one in Sydney.</p>
-      
-      <p>Phil Oye asks that some respect be shown to “those of us who are camping” when it comes to deciding where a Railscamp is in Winter. (This Railscamp has been in the MINUSES overnight). Having it in Brisbane during the Winter would be better. Phil also says that there’s no harm in queuing up the next <em>two</em> Railscamps.</p>
-      
+
+      <p>Phil Oye asks that some respect be shown to “those of us who are camping” when it comes to deciding where a Rails Camp is in Winter. (This Rails Camp has been in the MINUSES overnight). Having it in Brisbane during the Winter would be better. Phil also says that there’s no harm in queuing up the next <em>two</em> Rails Camps.</p>
+
       <p>OH: Phil suggests: “Mandatory camping.”</p>
-      
+
       <p>Keith Pitty suggests having a camp near Sydney for the next one, Brisbane for the camp after that.</p>
-      
+
       <p>Tim McEwan says that voting for members will be effected by who’s organising the next camp. Pat Allan replies, suggesting Dylan and Lachie are both made general members during the election.</p>
-      
+
       <h3 id="8_voting_for_vp__2_general_members">8. Voting for VP + 2 General Members</h3>
-      
+
       <p>Pat Allan: “What does a VP do?” Ben Schwarz: “Take a bullet for me. Na… supports me in what I do, someone who’s full of wisdom. Someone who’s quite senior in the Ruby Community…”</p>
-      
+
       <p>Jason Crane nominates Josh Price. Seconds from Phil Oye + others. Josh accepts.</p>
-      
+
       <p>David Goodlad nominates John Barton “on all the same reasons besides the one about being ‘good looking’“. Seconds from the audience. John Barton accepts.</p>
-      
+
       <p>Josh Price says “there’s more practical reasons for me being on the committee. I am organising the next RubyConf AU, I have access to the bank account and I’m already doing the role. … Helping Ruby Australia do all that stuff.”</p>
-      
+
       <p>John Barton says: “The main benefit for me is to be the representative for Victoria. Ben will be out in 6 months, and to add some perspective from there … I guess Josh is better”.</p>
-      
+
       <p>Josh Price: 24 votes. John Barton: 6 votes.</p>
-      
+
       <p>Josh Price is now Vice President of Ruby Australia.</p>
       <hr />
-      <p>Phil Oye nominates Lachie Cox for GM. Elle Meredith seconds, as does Jason Crane. “[jokingly] For the impending Railscamp in Sydney that will happen in Summer”. Lachie accepts.</p>
-      
+      <p>Phil Oye nominates Lachie Cox for GM. Elle Meredith seconds, as does Jason Crane. “[jokingly] For the impending Rails Camp in Sydney that will happen in Summer”. Lachie accepts.</p>
+
       <p>Keith Pitty nominates Elle Meredith. Jason Crane seconds. KP: “Ideal because she’s representing the diversity in the community.” Elle acccepts.</p>
-      
+
       <p>John Barton nominated by Gareth. John Barton accepts.</p>
-      
+
       <p>Wayne Robinson nominates Dylan Lacey. Seconded by Pat. Dylan accepts.</p>
-      
+
       <p>Suggestion to raise Committee Members from 6 to 8 (made by Pat Allan), so that all nominated can join the committee. Keith Pitty seconded.</p>
-      
+
       <p>Motion passed to expand general committee member numbers to 4.</p>
-      
-      <p>Josh Price brings up idea of having special spots on the committee for “Railscamp organisers”. Motion tabled.</p>
-      
+
+      <p>Josh Price brings up idea of having special spots on the committee for “Rails Camp organisers”. Motion tabled.</p>
+
       <p>Motion passed to elect John Barton, Elle Meredith, Lachie Cox and Dylan Lacey to the committee. Ruby Australia site to be updated with these members soon.</p>
-      
+
       <h3 id="8_discussion_of_ruby_australia_money">8. Discussion of Ruby Australia money</h3>
-      
-      <p>Phil Oye asks if we have a plan with the profit from Railscamps and Ruby Confs. Ben Schwarz says that the money will be used to ‘support Ruby and Ruby events’, mentions that the charter says that we’re a not-for-profit organisation.</p>
-      
+
+      <p>Phil Oye asks if we have a plan with the profit from Rails Camps and Ruby Confs. Ben Schwarz says that the money will be used to ‘support Ruby and Ruby events’, mentions that the charter says that we’re a not-for-profit organisation.</p>
+
       <p>Josh Price says that we need a safe buffer (“of about $50k”) just in case of the problem where we might have to cancel a conference.</p>
-      
+
       <p>Phil says “lowering the price of the conference <em>could</em> be a good way to use the available money.” Josh Price replies: “subsidising ticket prices for students would be a good way too”</p>
-      
-      <p>John Barton asks “can we formalize that a specific buffer is set aside in the case of emergencies? A specific amount that we know is earmarked so that we can dip into it if need be. [For Railscamps, etc]” Motion postponed until next committee meeting. It should be decided then if a report should be presented at the next General Meeting.</p>
-      
+
+      <p>John Barton asks “can we formalize that a specific buffer is set aside in the case of emergencies? A specific amount that we know is earmarked so that we can dip into it if need be. [For Rails Camps, etc]” Motion postponed until next committee meeting. It should be decided then if a report should be presented at the next General Meeting.</p>
+
       <p>Ben Schwarz suggests giving groups (such as RailsGirls) a certain chunk of cash to organise events too. Elle Meredith says that she will note down the expenses of the event and notify Ben of them.</p>
-      
+
       <p>Josh Price suggests reviewing any proposals for money for sponsoring Ruby nuturing within the community.</p>
-      
+
       <p>Motion passed.</p>
-      
+
       <p><strong>MEETING CLOSED: 6:10 pm</strong></p>
     </section>
     <footer role='contentinfo'>

--- a/site/general_meetings/2013-11-03.html
+++ b/site/general_meetings/2013-11-03.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>
@@ -69,163 +69,163 @@
       </nav>
     </aside>
     <section role='main'>
-      
+
       <h1 id="ruby_australia_annual_general_meeting_minutes">Ruby Australia Annual General Meeting Minutes</h1>
-      
+
       <p><strong>3rd November, 2013</strong></p>
-      
+
       <p><strong>Meeting open: 15:37</strong></p>
       <hr />
       <h2 id="agenda">Agenda</h2>
-      
+
       <h3 id="1_opening_statements">1. Opening statements</h3>
-      
-      <p>Pat Allan intro to Ruby Australia and what we do. All Railscamps and RubyConfs come under the banner The local Ruby meets do not come under the banner.</p>
-      
+
+      <p>Pat Allan intro to Ruby Australia and what we do. All Rails Camps and RubyConfs come under the banner The local Ruby meets do not come under the banner.</p>
+
       <p>Pat’s just the narrator, no official power.</p>
-      
+
       <p>The eight Committee members currently are:</p>
-      
+
       <ol>
       <li>Ben Schwarz (<em>President</em>)</li>
-      
+
       <li>Josh Price (<em>Vice-President</em>)</li>
-      
+
       <li>Jason Stirk (<em>Treasurer</em>)</li>
-      
+
       <li>Ryan Bigg (<em>Secretary</em>)</li>
-      
+
       <li>Lachie Cox (<em>General member</em>)</li>
-      
+
       <li>Elle Meredith (<em>General member</em>)</li>
-      
+
       <li>John Barton (<em>General member</em>)</li>
-      
+
       <li>Dylan Lacey (<em>General member</em>)</li>
       </ol>
-      
+
       <h3 id="2_presidents_report__ben_schwarz">2. President’s report - Ben Schwarz</h3>
-      
+
       <p>The reign of Ben Schwarz is coming to an end. We’re going to go through the code of conduct, it’s had input from our community and other communities. We’ve now firmed up support for RailsGirls through banking and insurance and sorting out sponsorship. Making the whole thing easier. Also looking at giving financial support @ $25 per attendee.</p>
-      
+
       <h3 id="3_vps_report__josh_price">3. VP’s report - Josh Price</h3>
-      
+
       <p>Financials are in shape, all things reconciled. Jason will give a detailed report.</p>
-      
+
       <h3 id="4_treasurers_report__jason_stirk">4. Treasurer’s report - Jason Stirk</h3>
-      
+
       <p>We have all the financials sorted, audited and approved. We’re in a very healthy situation. We currently have $123,724.70 in the bank account. Some expenses outstanding for this rails camp. In the last financial year (1 Jan - 31 Dec 2011) we had a profit of $45,301.31 and for EY2012 $110,838.06 from RubyConf 2013, about $78K profit. Breakdowns are broken down to event, welcome come and have a look. Reports will be on the website. Any members are entitled to view them.</p>
-      
+
       <p>Pat Allan put forward a motion to approve the financial reports, seconded by Jason Crane. <em>Motion carried.</em></p>
-      
+
       <p>Pat Allan put forward a motion to accept the previous meeting’s minutes, seconded by Jason Crane. <em>Motion carried.</em></p>
-      
-      <p>By attending a Railscamp you are automatically a member of Ruby Australia.</p>
-      
+
+      <p>By attending a Rails Camp you are automatically a member of Ruby Australia.</p>
+
       <h3 id="5_rubyconf">5. Rubyconf</h3>
-      
+
       <p>Josh Price talked about RubyConf 2014. On in Feb. Early bird tickets are on sale now. We’ve sold 100 or so tickets. Call for Proposals is now open till after RailsCamp. Still taking Proposals till it’s done. It’ll be held in Luna Park in Sydney. Aiming for 400 people or so. If anyone wants to sponsorship available, please talk to Josh Price or Steve Gilles. Keith asked about keynotes, nothing to announce yet. $545 + GST for early birds. 10 tickets or more get a discount. We have a scholarship available, Thoughtworks are sponsoring 8 tickets. Steve Gilles extended a huge thanks to Keith and Martin and the previous RubyConf team. 100 tickets sold without much effort.</p>
-      
-      <h3 id="6_current_railscamp">6. Current Railscamp</h3>
-      
+
+      <h3 id="6_current_railscamp">6. Current Rails Camp</h3>
+
       <p>Lachie is very pleased with this camp and its progress. We try to aim to break even on the camps, so we had to receive sponsorship and increase the ticket price this time. Hopefully it’s not something we have to do each year. The scholarship has worked really well. 12 sponsorships were arranged but quite a few people dropped out. Need to tweak that for next camp.</p>
-      
-      <h3 id="7_next_railscamp">7. Next Railscamp</h3>
-      
+
+      <h3 id="7_next_railscamp">7. Next Rails Camp</h3>
+
       <p>Dylan Lacey announces the next camp in QLD, somewhere 2 hours out of Brisbane. Date, location and costs will be announced at Ruby Conf. Sometime before the end of May due to restrictions. Somewhere more beachy. Looking for suggestions. We’ll be having an intro session for noobs in each city to see what they might expect.</p>
-      
+
       <p>Let’s think about the camp after next, where should it be? Who’s going to organise it? Canberra? Perth, it’s been a while.</p>
-      
+
       <p>Feedback on this camp, please share with Lachie and Dylan.</p>
-      
+
       <h3 id="8_code_of_conduct">8. Code of Conduct</h3>
-      
+
       <p>Next item is the <a href="/code-of-conduct.html">Code of Conduct</a>, Pat Allan will read through it. It’s on github. <strong>Pat reads it</strong></p>
-      
+
       <p>Pat puts forward a motion that we accept it. Seconded by Luke Chadwick. No dissenting voices. <em>Motion passed.</em></p>
-      
+
       <p>Matt Allen said we’ll run a anonymous feedback form.</p>
-      
+
       <p>Leonard says that the code of conduct doesn’t explicitly name what is a violation. What happens when it is violated? Is there a dispute process.</p>
-      
+
       <p>Lachie says it’s not a legal document, Leonard says it’d be better if it was more explicit.</p>
-      
+
       <p>Leonard puts forward that we also create a dispute recommendation process.</p>
-      
+
       <p>Ben Schwarz mentioned that we decided very early that there was not going to be a list of illegal things. So people won’t game it. Dispute resolution is a good idea. It will be hosted in the Github repo along with other documents.</p>
-      
+
       <p><em>Motion passed to accept the code of conduct.</em></p>
-      
+
       <p>Dylan L says dispute resolution thought process is that each event may need a specific instance.</p>
-      
+
       <p>The motion is that Ruby Australia puts together a template for specific events.</p>
-      
+
       <p>Brenton suggests that risk assessment may be done on a per event basis.</p>
-      
+
       <p>Leonard puts forward a motion for a dispute resolution template. Seconded by Andrew Harvey. <em>Motion passed.</em></p>
-      
+
       <p>A motion that specific event can modify the template by individual event organisers, seconded by Lachlan Hardy. <em>Motion passed.</em></p>
-      
+
       <h3 id="9_committee_elections">9. Committee elections</h3>
-      
+
       <h4 id="president">President</h4>
-      
+
       <p>Keith Pitty nominated Matt Allen, seconded by Josh Price. <em>Elected unopposed.</em></p>
-      
+
       <h4 id="treasurer">Treasurer</h4>
-      
+
       <p>Pat Allan nominated Jason Stirk to continue, Josh Price seconded. <em>Elected unopposed.</em></p>
-      
+
       <h4 id="secretary">Secretary</h4>
-      
+
       <p>Pat Allan nominated Leonard Garvey, Leonard rejected due to not being in the country Jason nominated Steve Gilles. <em>Elected unopposed.</em></p>
-      
+
       <p>Lachlan Hardy suggested that 2 people from Lookahead is maybe not a good idea. <em>Steve stepped down.</em></p>
-      
+
       <p>Steve nominated Luke Chadwick, Luke accepted. <em>Elected unopposed.</em></p>
-      
+
       <h4 id="summary">Summary</h4>
-      
+
       <ul>
       <li>President: Ben Schwarz succeeded by Matt Allen</li>
-      
+
       <li>Secretary: Ryan Bigg succeeded by Luke Chadwick</li>
-      
+
       <li>all other members remain as above</li>
       </ul>
-      
+
       <h3 id="10_general_business">10. General Business</h3>
-      
-      <h4 id="railscamp_hardware">Railscamp hardware</h4>
-      
-      <p>Discussion around the hardware for Railscamps. Chris had to do it all, on his own laptop. Would it make sense to purchase some inside the association that would make railscamps easier to organise, someone has to start again.</p>
-      
+
+      <h4 id="railscamp_hardware">Rails Camp hardware</h4>
+
+      <p>Discussion around the hardware for Rails Camps. Chris had to do it all, on his own laptop. Would it make sense to purchase some inside the association that would make railscamps easier to organise, someone has to start again.</p>
+
       <p>Jason Stirk put forward a motion that some hardware is acquired to be used at events. Seconded by Keith Pitty.</p>
-      
-      <p>Should we focus on the specific problem just for Railscamps? Tim McEwan asked about how we move it around the country.</p>
-      
-      <p>Lachie Cox put forward a motion The Ruby Australia committee will take input in aquire hardware to support Railscamps before next Railscamp. Seconded by Leonard Garvey <em>Motion passed.</em></p>
-      
-      <h4 id="railscamp_internet">Railscamp Internet</h4>
-      
+
+      <p>Should we focus on the specific problem just for Rails Camps? Tim McEwan asked about how we move it around the country.</p>
+
+      <p>Lachie Cox put forward a motion The Ruby Australia committee will take input in aquire hardware to support Rails Camps before next Rails Camp. Seconded by Leonard Garvey <em>Motion passed.</em></p>
+
+      <h4 id="railscamp_internet">Rails Camp Internet</h4>
+
       <p>Nigel asked about potential of getting internet to a railscamp.</p>
-      
+
       <p>Brenton says it’s really hard.</p>
-      
+
       <p><em>Not carried, more discussion required.</em></p>
-      
-      <h4 id="railscamp_communication">Railscamp communication</h4>
-      
-      <p>Discussion about how to communicate that some people need help and some can help as Railscamps. Maybe use internal github. twetter? Talk about it with camp organisers. Not really a Ruby Australia issue.</p>
-      
+
+      <h4 id="railscamp_communication">Rails Camp communication</h4>
+
+      <p>Discussion about how to communicate that some people need help and some can help as Rails Camps. Maybe use internal github. twetter? Talk about it with camp organisers. Not really a Ruby Australia issue.</p>
+
       <h3 id="11_any_other_business">11. Any other business</h3>
-      
+
       <p>RailsGirls is now in 4 cities.</p>
-      
+
       <p>Greg McIntyre asked where should these discussions should be held in-between events? Mention of Seattle.RB who do a lot of work under the banner. If we need to pay for something, can RubyAustralia pay for that? Answer is yes.</p>
-      
+
       <p>Darcy L puts forward a motion that pre-railscamp events be endorse before Ruby events. He’ll put a proposal together.</p>
-      
+
       <p><strong>Meeting closed at 16:36</strong></p>
     </section>
     <footer role='contentinfo'>

--- a/site/general_meetings/2014-05-10.html
+++ b/site/general_meetings/2014-05-10.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>
@@ -69,169 +69,169 @@
       </nav>
     </aside>
     <section role='main'>
-      
+
       <h1 id="ruby_australia_general_meeting_minutes">Ruby Australia General Meeting Minutes</h1>
-      
+
       <p><strong>10th May, 2014</strong></p>
-      
+
       <p><strong>Meeting open: 5:00pm</strong></p>
       <hr />
       <h2 id="agenda">Agenda</h2>
-      
+
       <h3 id="1_opening_statements">1. Opening statements</h3>
-      
+
       <p>Pat Allan opens the meeting.</p>
-      
+
       <p>Pat’s just the narrator, no official power.</p>
-      
+
       <p>The eight Committee members currently are:</p>
-      
+
       <ul>
       <li>Matt Allen (<em>President</em>)</li>
-      
+
       <li>Josh Price (<em>Vice-President</em>)</li>
-      
+
       <li>Jason Stirk (<em>Treasurer</em>)</li>
-      
+
       <li>Luke Chadwick (<em>Secretary</em>)</li>
-      
+
       <li>Lachie Cox (<em>General member</em>)</li>
-      
+
       <li>Elle Meredith (<em>General member</em>)</li>
-      
+
       <li>John Barton (<em>General member</em>)</li>
-      
+
       <li>Dylan Lacey (<em>General member</em>)</li>
       </ul>
-      
+
       <h3 id="treasurers_report__jason_stirk">Treasurer’s report - Jason Stirk</h3>
-      
+
       <p>The accountant has highlighted a problem with the report.</p>
-      
+
       <p>Matt (current president) has been given access to the bank accounts. This is primarily for redundancy. A discussion is needed in the committee about whether the incoming VP is also given access.</p>
-      
+
       <p>The Balance sheet has been done up to 31 March. Jason reports that we are still in a very health position.</p>
-      
+
       <p>It has been identified that the Camps should not be running a profit. They are for the members.</p>
-      
+
       <ul>
       <li>Moved: Dylan Lacey</li>
-      
+
       <li>Seconded: Noel Kelly</li>
-      
+
       <li>Outcome: Motion passed without dissent.</li>
       </ul>
-      
+
       <h3 id="rubyconf_report__steve_gilles">RubyConf Report - Steve Gilles</h3>
-      
+
       <p>The organisers are very happy about the event. The venue was a great success.</p>
-      
+
       <p>This could not have happened without Ruby Australia.</p>
-      
+
       <p>Decision was made to not make too much profit. The RailsGirls event was free.</p>
-      
+
       <ul>
       <li>Moved: Pat Allan</li>
-      
+
       <li>Seconded: Craig Read</li>
-      
+
       <li>Outcome: Motion passed without dissent.</li>
       </ul>
-      
+
       <h3 id="vps_report__josh_price">VP’s Report - Josh Price</h3>
-      
+
       <p>Greetings from not so sunny Sydney!</p>
-      
+
       <p>It’s been another successful year for Ruby Australia supporting the Ruby community in Australia. It’s a wonderful community and I’m extremely proud to be a part of it.</p>
-      
-      <p>Together we’ve shipped some amazing events: another fantastic Rubyconf, 2 amazing Railscamps, a host of wonderful RailsGirls events, and all of the various meetups that happen around Australia.</p>
-      
+
+      <p>Together we’ve shipped some amazing events: another fantastic Rubyconf, 2 amazing Rails Camps, a host of wonderful RailsGirls events, and all of the various meetups that happen around Australia.</p>
+
       <p>Most importantly I’d like to thank everyone who’s helped to make these events possible as well as all of the committee members past and present. Untold hours of behind the scenes work goes into making these events possible. So if you see an organiser, don’t forget to say thanks… :)</p>
-      
+
       <p>It certainly feels to me like our community has grown more diverse, and more vibrant and this should be celebrated.</p>
-      
-      <p>Thanks everyone, have a great Railscamp!</p>
-      
+
+      <p>Thanks everyone, have a great Rails Camp!</p>
+
       <p>Cheers, Josh</p>
-      
+
       <p>PS: I nominate Pat Allan to replace me as Vice President of Ruby Australia in absentia</p>
-      
+
       <ul>
       <li>Moved: Pat Allan</li>
-      
+
       <li>Seconded: Luke Arndt</li>
-      
+
       <li>Outcome: Approved, No Dissent</li>
       </ul>
-      
+
       <h3 id="pats_report_on_upcoming_events">Pat’s report on upcoming events</h3>
-      
+
       <ul>
       <li>Next RailsCamp will be held in Perth.</li>
-      
+
       <li>Organizers are needed for RailCamp+1</li>
-      
+
       <li>The location for RubyConf 2015 has been selected. It will be held at the Deakin Edge Theatre in Melbourne.</li>
       </ul>
-      
+
       <h2 id="elections">Elections</h2>
-      
+
       <p>The VP and all the General Committee members are up for election.</p>
-      
+
       <h3 id="vp_election">VP Election</h3>
-      
+
       <p>Josh Price nominates Pat Allan. Seconded by Steve Gilles</p>
-      
+
       <p>Question about whether it would be a problem having a Conference and Commitee cross over, with workload.</p>
-      
+
       <p>Pat Allan is elected unanimously.</p>
-      
+
       <h3 id="general_members">General Members</h3>
-      
+
       <ul>
       <li>Keith Pitt - Nominated by Lachlan Hardy, seconded by Dylan Lacey</li>
-      
+
       <li>Mel Sherrin - Nominated by Dylan Lacey, seconded by Wayne Robinson</li>
-      
+
       <li>Rob Jacoby - Nominated by Dylan Lacey, seconded by Richie Khoo</li>
-      
+
       <li>Luke Arndt - Nominated by Steve Gilles, seconded by Ben Turner</li>
-      
+
       <li>Andrew Harvey - Nominated by self, seconded by Pat Allan</li>
       </ul>
-      
+
       <p>After discussion Andrew withdraws his nomination to ensure Mel Sherrin will stand.</p>
-      
+
       <ul>
       <li>Motion to accept all: Richie Khoo</li>
-      
+
       <li>Seconded: Lachlan Hardy</li>
-      
+
       <li>Approved without dissent.</li>
       </ul>
-      
+
       <h2 id="general_business">General Business</h2>
-      
+
       <p>Richie Khoo wants to put a request to the get a certain workshop to come to Australia for RubyConf AU.</p>
-      
+
       <p>Discussion supports the idea but no motion is put forward.</p>
-      
+
       <h3 id="location_of_the_rubyconf">Location of the RubyConf</h3>
-      
+
       <p>Dylan Lacey asks if we need a process for selecting the location of the next RubyConf.</p>
-      
+
       <p>Nigel Rausch put forward Brisbane to Josh Price in the middle of last year.</p>
-      
+
       <p>Discussion around profit being a consideration.</p>
-      
+
       <p>Elle Meredith likes the simplicity of volunteering.</p>
-      
+
       <p>Lachlan Hardy moves that RubyAustralia announces a period of time that they’re accepting expressions of interest. Seconded by Wayne Robinson and approved without dissent.</p>
-      
+
       <h3 id="railsgirls_support">RailsGirls support</h3>
-      
+
       <p>Dylan Lacey wants to check if RailsGirls is getting enough support? Jason Stirk reports that they are being offered $25 a head and not needing all of it.</p>
-      
+
       <p><strong>Meeting closed: 6:00pm</strong></p>
     </section>
     <footer role='contentinfo'>

--- a/site/index.html
+++ b/site/index.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>

--- a/site/join-ruby-australia.html
+++ b/site/join-ruby-australia.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>

--- a/site/meetups/adl.html
+++ b/site/meetups/adl.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>

--- a/site/meetups/bne.html
+++ b/site/meetups/bne.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>

--- a/site/meetups/can.html
+++ b/site/meetups/can.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>

--- a/site/meetups/mel.html
+++ b/site/meetups/mel.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>

--- a/site/meetups/mel/april-2012.html
+++ b/site/meetups/mel/april-2012.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>

--- a/site/meetups/mel/may-2012.html
+++ b/site/meetups/mel/may-2012.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>

--- a/site/meetups/per.html
+++ b/site/meetups/per.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>

--- a/site/meetups/syd.html
+++ b/site/meetups/syd.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>
@@ -73,13 +73,13 @@
         <h3>Sydney Ruby</h3>
         <article>
           <h4>Next Meetup</h4>
-          
+
           <h4 id="we_meet_on_the_second_tuesday_of_every_month">We meet <a href="https://github.com/rails-oceania/roro/wiki/">on the second Tuesday of every month</a></h4>
-          
+
           <h4 id="630_for_7pm_at_the_king_st_brewhouse_at_king_st_wharf_on_darling_harbour_sydney">6:30 (for 7pm) at the <a href="http://kingstbrewhouse.com.au/contact/">King St Brewhouse</a> at King St Wharf on Darling Harbour, Sydney.</h4>
-          
+
           <p><a href="https://github.com/rails-oceania/roro/wiki/">See our wiki for information</a> on upcoming meetings. Please put your name down if you’d like to give a talk.</p>
-          
+
           <p>Everyone welcome! We’d love to see you there.</p>
         </article>
         <article>

--- a/site/previous-committee-members.html
+++ b/site/previous-committee-members.html
@@ -33,7 +33,7 @@
             <a href='/code-of-conduct.html'>Code of Conduct</a>
           </li>
           <li>
-            <a href='/#railscamp'>Railscamp</a>
+            <a href='/#railscamp'>Rails Camp</a>
           </li>
           <li>
             <a href='/#rubyconf-au'>RubyConf AU</a>
@@ -217,7 +217,7 @@
             <p class='position'>President: Jan 2012 &ndash; Jun 2012</p>
           </header>
           <div class='bio'>
-            <p>A long-time participant, former convener of and occasional presenter at Sydney Ruby meetups, Keith led the organisation of Railscamp 9 at Lake Ainsworth in 2011 and co-organised the inaugural <a href="http://rubyconf.org.au">RubyConfAU</a> in Melbourne in 2013. He runs <a href="http://www.cockatoosoftware.com.au">Cockatoo Software</a>.</p>
+            <p>A long-time participant, former convener of and occasional presenter at Sydney Ruby meetups, Keith led the organisation of Rails Camp 9 at Lake Ainsworth in 2011 and co-organised the inaugural <a href="http://rubyconf.org.au">RubyConfAU</a> in Melbourne in 2013. He runs <a href="http://www.cockatoosoftware.com.au">Cockatoo Software</a>.</p>
             <p>Away from computers, he loves sport, especially cricket, golf and Aussie Rules. And single malt whisky.</p>
           </div>
           <div class='contact'>
@@ -261,7 +261,7 @@
             <p class='position'>Treasurer: Jan 2012 &ndash; Dec 2012</p>
           </header>
           <div class='bio'>
-            <p>After growing up in Sweden, Sebastian escaped to the US in 2007 and moved down under in 2009. He now lives in Melbourne with his partner and two fur children, and works as a development manager at <a href="http://www.envato.com">Envato</a>. He is also a certified baseball nut. Having organised Railscamp X, he is excited to continue working with the Australian Ruby community.</p>
+            <p>After growing up in Sweden, Sebastian escaped to the US in 2007 and moved down under in 2009. He now lives in Melbourne with his partner and two fur children, and works as a development manager at <a href="http://www.envato.com">Envato</a>. He is also a certified baseball nut. Having organised Rails Camp X, he is excited to continue working with the Australian Ruby community.</p>
           </div>
           <div class='contact'>
             <a href='http://twitter.com/vonconrad'>@vonconrad</a>


### PR DESCRIPTION
This is the proper name, right? 

Also welcome to close if this is unwelcome. :heart:
