### PR TITLE
Update the Melbourne Ruby Meetup organisers

### DIFF
--- a/pages/meetups/mel.html.haml
+++ b/pages/meetups/mel.html.haml
@@ -20,8 +20,8 @@
   %article
     %h4 Organisers
     %ul
-      %li Mario Visic (<a href="http://twitter.com/mariovisic">@mariovisic</a>)
-      %li Pat Allan (<a href="http://twitter.com/pat">@pat</a>)
+      %li Gareth Townsend (<a href="http://twitter.com/quamen">@quamen</a>)
+      %li Matt Allen (<a href="http://twitter.com/mattallen">@mattallen</a>)
 
   %article
     %h4 Meeting Format

--- a/site/meetups/mel.html
+++ b/site/meetups/mel.html
@@ -89,8 +89,8 @@
         <article>
           <h4>Organisers</h4>
           <ul>
-            <li>Mario Visic (<a href="http://twitter.com/mariovisic">@mariovisic</a>)</li>
-            <li>Pat Allan (<a href="http://twitter.com/pat">@pat</a>)</li>
+            <li>Gareth Townsend (<a href="http://twitter.com/quamen">@quamen</a>)</li>
+            <li>Matt Allen (<a href="http://twitter.com/mattallen">@mattallen</a>)</li>
           </ul>
         </article>
         <article>


### PR DESCRIPTION
The organisers of the Melbourne Ruby Meetup are changing: https://groups.google.com/forum/#!topic/rails-oceania/eYQPQ47uV7w

* Remove Pat and Mario
* Add Gareth and Matt